### PR TITLE
feat: add secure worker sync and link diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A macOS menu bar app by [measured.one](https://measured.one) that turns a handfu
             distribute-metal.yaml
 ```
 
-Every Mac in the cluster runs the same two things: the **menu bar app** (coordinator UI) and the **Python agent** (HTTP worker on port 8477). Bonjour handles discovery. A shared token prevents unauthorized access. The MCP server lets AI agents in Cursor inspect the cluster and generate job specs.
+Every Mac in the cluster runs the **Python agent** (HTTP worker on port 8477). The **menu bar app** runs on the coordinator and may also run on workers if you want local visibility. Bonjour handles discovery. A shared token protects mutating agent routes. The MCP server is optional; it remains useful for Cursor-driven inspection and YAML generation, but secure sync and benchmarking no longer depend on it.
 
 ## Requirements
 
@@ -101,11 +101,22 @@ Peers find each other in two ways:
 
 2. **Manual.** Click **+** in the peers section and enter an IP address. Useful for machines on different subnets.
 
-Each discovered peer is immediately probed via `GET /status` to verify the agent is running and to pull hardware info (chip, memory, macOS version, mccl version, disk space). Peers show as **ready**, **busy**, or **offline**.
+Each discovered peer is immediately probed via `GET /status` to verify the agent is running and to pull hardware info (chip, memory, macOS version, mccl version, disk space). A peer can therefore be:
 
-## Step 4: Check the cluster with MCP
+- **discovered**: visible on Bonjour, probe not completed yet
+- **unreachable**: visible on Bonjour, but the agent probe failed
+- **agent failed**: the agent answered, but reported a failed state
+- **ready** or **busy**: the agent answered and is healthy enough to classify
 
-The MCP server is the AI-powered layer for cluster inspection and job setup. It runs inside Cursor and is configured automatically via `.cursor/mcp.json`.
+## Step 3b: Secure sync access
+
+Before the first push sync, the coordinator authorizes a per-worker SSH key on that worker. The key is restricted to a single forced `rsync --server` command rooted under the DistributeMetal workspace, so it can accept inbound job files but cannot be used by that worker to browse the coordinator's live source directory.
+
+This bootstrap happens automatically when you run a job. The peer row context menu can also run a **Test Link** action, which exercises the real peer-to-peer network path using the worker agents.
+
+## Step 4: Check the cluster with MCP (optional)
+
+The MCP server is the AI-powered layer for cluster inspection and job setup. It runs inside Cursor and is configured automatically via `.cursor/mcp.json`. You do not need it to pair workers, sync code, run jobs, or benchmark the network path.
 
 **What the MCP can see:**
 
@@ -178,6 +189,8 @@ version: 1
 
 project:
   name: my-training-run
+  root: .
+  working_dir: .
   entrypoint: train.py
   include:
     - "**/*.py"
@@ -202,7 +215,7 @@ training:
 data: []
 
 sync:
-  mode: bulk
+  mode: rsync-push
   parallel_connections: 8
 
 cleanup:
@@ -234,11 +247,19 @@ sequenceDiagram
     participant A2 as Agent rank 1
 
     U->>C: Open YAML, click Run
+    par Initialize
+        C->>A1: POST /jobs/init
+        C->>A2: POST /jobs/init
+    end
+    par Sync
+        C->>A1: SSH bootstrap + rsync push
+        C->>A2: SSH bootstrap + rsync push
+    end
     par Prepare
         C->>A1: POST /jobs/prepare
         C->>A2: POST /jobs/prepare
     end
-    Note over A1,A2: Create workspace, uv sync
+    Note over A1,A2: Promote synced files, then uv sync
     loop Poll until ready
         C->>A1: GET /status
         C->>A2: GET /status
@@ -251,9 +272,11 @@ sequenceDiagram
     U->>C: Stop / Clean when done
 ```
 
-**Prepare:** each agent creates a workspace at `~/Library/Application Support/DistributeMetal/jobs/<job_id>/`, provisions a `uv` virtual environment from `pyproject.toml`.
+**Initialize + sync:** the coordinator creates a per-job workspace on each worker, bootstraps a restricted SSH push key, and pushes a filtered copy of the project and coordinator-sourced data into the worker job workspace via `rsync` over SSH. Workers never receive credentials that let them read back into the coordinator's live project tree.
 
-**Launch:** each agent starts `torchrun` with `--node_rank`, `--master_addr`, `--master_port`, `--world_size`. MCCL handles gradient all-reduce over Metal.
+**Prepare:** each agent promotes the synced files into `~/Library/Application Support/DistributeMetal/jobs/<job_id>/`, then provisions a `uv` virtual environment from the synced `pyproject.toml`.
+
+**Launch:** each agent starts `torchrun` with the entrypoint, working directory, environment, and script arguments from the job spec. MCCL handles gradient all-reduce over Metal.
 
 **Clean:** when finished, click **Clean** to remove workspaces from all peers.
 
@@ -313,10 +336,10 @@ measured.one.distribute-metal/
 └── LICENSE                   # MIT
 ```
 
-## Current limitations (v0.1)
+## Current limitations
 
-- **No automatic code sync.** Project source must be present at each agent's workspace before running. Use `rsync`, a shared volume, or copy manually. Bundle upload is defined but not yet implemented.
-- **Entrypoint is fixed at `train.py`.** The agent does not yet read `project.entrypoint` from the YAML spec.
+- **Sync currently uses coordinator-driven rsync over SSH.** There is still no worker-side pull mode or shared-volume abstraction; the coordinator must be able to reach each worker over SSH.
+- **Bundle upload remains unimplemented.** The HTTP bundle endpoint is still a placeholder because the secure path is rsync push, not agent-hosted archive ingest.
 - **No completion polling from the UI.** The coordinator does not automatically detect when training finishes.
 - **MCP peer list is static.** The MCP reads peers from a YAML file rather than from Bonjour. Bonjour-discovered peers in the menu bar app are not automatically synced to the MCP config.
 

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -19,3 +19,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/distribute_metal_agent"]
+
+[tool.pytest.ini_options]
+markers = [
+    "unit: fast unit tests",
+]

--- a/agent/src/distribute_metal_agent/bench.py
+++ b/agent/src/distribute_metal_agent/bench.py
@@ -1,0 +1,163 @@
+"""Bounded in-process TCP benchmarking for peer link tests."""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from dataclasses import dataclass
+
+from .models import BenchResultResponse, BenchResultState, BenchSenderResponse
+
+MAX_CONCURRENT_RECEIVERS = 4
+RECEIVER_TIMEOUT_SECONDS = 30
+RESULT_TTL_SECONDS = 300
+DEFAULT_BUFFER_SIZE = 1024 * 1024
+
+
+@dataclass
+class BenchSession:
+    session_id: str
+    server: socket.socket
+    port: int
+    max_bytes: int
+    created_at: float
+    state: BenchResultState = BenchResultState.pending
+    bytes_received: int = 0
+    duration_seconds: float | None = None
+    error: str | None = None
+
+
+_sessions: dict[str, BenchSession] = {}
+_lock = threading.Lock()
+
+
+def start_receiver(session_id: str, max_bytes: int) -> int:
+    with _lock:
+        _cleanup_expired_locked()
+        if session_id in _sessions:
+            raise ValueError(f"Benchmark session already exists: {session_id}")
+
+        pending_receivers = sum(1 for session in _sessions.values() if session.state == BenchResultState.pending)
+        if pending_receivers >= MAX_CONCURRENT_RECEIVERS:
+            raise RuntimeError("Too many active benchmark receivers")
+
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("0.0.0.0", 0))
+        server.listen(1)
+        server.settimeout(RECEIVER_TIMEOUT_SECONDS)
+
+        session = BenchSession(
+            session_id=session_id,
+            server=server,
+            port=server.getsockname()[1],
+            max_bytes=max_bytes,
+            created_at=time.time(),
+        )
+        _sessions[session_id] = session
+
+    thread = threading.Thread(target=_run_receiver, args=(session_id,), daemon=True)
+    thread.start()
+    return session.port
+
+
+def run_sender(
+    session_id: str,
+    host: str,
+    port: int,
+    bytes_to_send: int,
+    chunk_size: int,
+) -> BenchSenderResponse:
+    payload = b"\0" * min(chunk_size, DEFAULT_BUFFER_SIZE)
+
+    connect_started = time.monotonic()
+    with socket.create_connection((host, port), timeout=RECEIVER_TIMEOUT_SECONDS) as client:
+        connect_latency_ms = (time.monotonic() - connect_started) * 1000
+        started = time.monotonic()
+        remaining = bytes_to_send
+        while remaining > 0:
+            piece = payload[: min(len(payload), remaining)]
+            client.sendall(piece)
+            remaining -= len(piece)
+        duration_seconds = max(time.monotonic() - started, 1e-6)
+
+    throughput_mbps = (bytes_to_send * 8) / duration_seconds / 1_000_000
+    return BenchSenderResponse(
+        session_id=session_id,
+        bytes_sent=bytes_to_send,
+        duration_seconds=duration_seconds,
+        throughput_mbps=throughput_mbps,
+        connect_latency_ms=connect_latency_ms,
+    )
+
+
+def get_result(session_id: str) -> BenchResultResponse:
+    with _lock:
+        _cleanup_expired_locked()
+        session = _sessions.get(session_id)
+        if session is None:
+            raise KeyError(session_id)
+        return BenchResultResponse(
+            session_id=session.session_id,
+            state=session.state,
+            bytes_received=session.bytes_received,
+            duration_seconds=session.duration_seconds,
+            throughput_mbps=_throughput(session.bytes_received, session.duration_seconds),
+            error=session.error,
+        )
+
+
+def _run_receiver(session_id: str) -> None:
+    with _lock:
+        session = _sessions.get(session_id)
+    if session is None:
+        return
+
+    connection: socket.socket | None = None
+    try:
+        connection, _ = session.server.accept()
+        connection.settimeout(RECEIVER_TIMEOUT_SECONDS)
+
+        total = 0
+        started = time.monotonic()
+        while total < session.max_bytes:
+            chunk = connection.recv(min(DEFAULT_BUFFER_SIZE, session.max_bytes - total))
+            if not chunk:
+                break
+            total += len(chunk)
+
+        duration_seconds = max(time.monotonic() - started, 1e-6)
+        with _lock:
+            current = _sessions.get(session_id)
+            if current is not None:
+                current.bytes_received = total
+                current.duration_seconds = duration_seconds
+                current.state = BenchResultState.completed
+    except Exception as exc:
+        with _lock:
+            current = _sessions.get(session_id)
+            if current is not None:
+                current.state = BenchResultState.failed
+                current.error = str(exc)
+    finally:
+        if connection is not None:
+            connection.close()
+        session.server.close()
+
+
+def _cleanup_expired_locked() -> None:
+    cutoff = time.time() - RESULT_TTL_SECONDS
+    expired = [session_id for session_id, session in _sessions.items() if session.created_at < cutoff]
+    for session_id in expired:
+        session = _sessions.pop(session_id)
+        try:
+            session.server.close()
+        except OSError:
+            pass
+
+
+def _throughput(bytes_received: int, duration_seconds: float | None) -> float | None:
+    if duration_seconds is None or duration_seconds <= 0:
+        return None
+    return (bytes_received * 8) / duration_seconds / 1_000_000

--- a/agent/src/distribute_metal_agent/cli.py
+++ b/agent/src/distribute_metal_agent/cli.py
@@ -23,7 +23,11 @@ def cmd_init(args: argparse.Namespace) -> None:
         print(f"Error: no pyproject.toml in {project}", file=sys.stderr)
         sys.exit(1)
 
-    entrypoint = _detect_entrypoint(project)
+    detected_entrypoint = _detect_entrypoint(project)
+    working_dir = str(Path(detected_entrypoint).parent)
+    if working_dir == ".":
+        working_dir = "."
+    entrypoint = Path(detected_entrypoint).name
     name = project.name.lower().replace(" ", "-")
     has_lockfile = (project / "uv.lock").exists()
     data_dirs = _detect_data_dirs(project)
@@ -45,6 +49,8 @@ def cmd_init(args: argparse.Namespace) -> None:
 
 project:
   name: "{name}"
+  root: "."
+  working_dir: "{working_dir}"
   entrypoint: "{entrypoint}"
   include:
 {include_lines}
@@ -68,7 +74,7 @@ training:
 {data_block}
 
 sync:
-  mode: "bulk"
+  mode: "rsync-push"
   parallel_connections: 8
   chunk_size_mb: 64
 
@@ -95,6 +101,7 @@ validation:
     print(f"Created {out}")
     print(f"  project:    {name}")
     print(f"  entrypoint: {entrypoint}")
+    print(f"  working dir: {working_dir}")
     print(f"  python:     {python_version}")
     if data_dirs:
         print(f"  data dirs:  {', '.join(data_dirs)}")

--- a/agent/src/distribute_metal_agent/models.py
+++ b/agent/src/distribute_metal_agent/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -17,9 +16,90 @@ class AgentState(str, Enum):
     cleaned = "cleaned"
 
 
+class ProjectSpec(BaseModel):
+    name: str
+    root: str = "."
+    working_dir: str = "."
+    entrypoint: str
+    include: list[str] = Field(default_factory=list)
+    exclude: list[str] = Field(default_factory=list)
+
+
+class PythonSpec(BaseModel):
+    version: str
+    pyproject: str
+    lockfile: str = ""
+
+
+class TorchrunSpec(BaseModel):
+    nproc_per_node: int = 1
+    master_port: int = 29500
+    script_args: list[str] = Field(default_factory=list)
+
+
+class Rank0OnlySpec(BaseModel):
+    save_checkpoints: bool = True
+    write_logs: bool = True
+
+
+class TrainingSpec(BaseModel):
+    backend: str
+    torchrun: TorchrunSpec
+    env: dict[str, str] = Field(default_factory=dict)
+    checkpoint_dir: str = "checkpoints"
+    rank0_only: Rank0OnlySpec = Field(default_factory=Rank0OnlySpec)
+
+
+class DataSpec(BaseModel):
+    name: str | None = None
+    source: str
+    url: str | None = None
+    path: str
+    sha256: str | None = None
+    size_bytes: int | None = None
+    unpack: str | None = None
+    description: str | None = None
+
+
+class SyncSpec(BaseModel):
+    mode: str = "rsync-push"
+    parallel_connections: int = 8
+    chunk_size_mb: int = 64
+    preferred_interface: str = "auto"
+
+
+class CleanupSpec(BaseModel):
+    delete_venv_on_success: bool = True
+    delete_source_on_success: bool = True
+    delete_data_on_success: bool = False
+    retain_logs_days: int = 7
+
+
+class ValidationSpec(BaseModel):
+    require_arm64: bool = True
+    min_free_disk_gb: int = 10
+    required_tools: list[str] = Field(default_factory=list)
+    check_firewall: bool = True
+
+
+class JobSpec(BaseModel):
+    version: int = 1
+    project: ProjectSpec
+    python: PythonSpec
+    training: TrainingSpec
+    data: list[DataSpec] = Field(default_factory=list)
+    sync: SyncSpec = Field(default_factory=SyncSpec)
+    cleanup: CleanupSpec = Field(default_factory=CleanupSpec)
+    validation: ValidationSpec = Field(default_factory=ValidationSpec)
+
+
+class JobInitRequest(BaseModel):
+    job_id: str
+    spec: JobSpec
+
+
 class PrepareRequest(BaseModel):
     job_id: str
-    spec: dict[str, Any]
 
 
 class LaunchRequest(BaseModel):
@@ -43,6 +123,61 @@ class AgentResponse(BaseModel):
     ok: bool
     message: str | None = None
     state: AgentState | None = None
+
+
+class SSHAuthorizeRequest(BaseModel):
+    public_key: str
+    key_name: str | None = None
+
+
+class SSHAuthorizeResponse(BaseModel):
+    ok: bool = True
+    message: str | None = None
+    ssh_user: str
+    host_keys: list[str]
+    receive_root: str
+    rsync_available: bool
+
+
+class BenchReceiverRequest(BaseModel):
+    session_id: str
+    max_bytes: int = Field(default=128 * 1024 * 1024, ge=1, le=256 * 1024 * 1024)
+
+
+class BenchReceiverResponse(BaseModel):
+    session_id: str
+    port: int
+
+
+class BenchSenderRequest(BaseModel):
+    session_id: str
+    host: str
+    port: int
+    bytes_to_send: int = Field(default=128 * 1024 * 1024, ge=1, le=256 * 1024 * 1024)
+    chunk_size: int = Field(default=1024 * 1024, ge=4096, le=4 * 1024 * 1024)
+
+
+class BenchSenderResponse(BaseModel):
+    session_id: str
+    bytes_sent: int
+    duration_seconds: float
+    throughput_mbps: float
+    connect_latency_ms: float
+
+
+class BenchResultState(str, Enum):
+    pending = "pending"
+    completed = "completed"
+    failed = "failed"
+
+
+class BenchResultResponse(BaseModel):
+    session_id: str
+    state: BenchResultState
+    bytes_received: int = 0
+    duration_seconds: float | None = None
+    throughput_mbps: float | None = None
+    error: str | None = None
 
 
 class StatusResponse(BaseModel):

--- a/agent/src/distribute_metal_agent/rsync_guard.py
+++ b/agent/src/distribute_metal_agent/rsync_guard.py
@@ -1,0 +1,61 @@
+"""Restrict inbound rsync to push-only writes under a single receive root."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from pathlib import Path
+
+
+def resolve_rsync_command(original_command: str, root: Path) -> list[str]:
+    """Validate and rewrite an rsync server command under ``root``.
+
+    Only ``rsync --server`` push commands are accepted. Pull mode is rejected,
+    and the final target path must stay inside ``root`` after normalization.
+    """
+    args = shlex.split(original_command)
+    if len(args) < 3 or args[0] != "rsync" or "--server" not in args:
+        raise ValueError("Only rsync --server commands are allowed")
+    if "--sender" in args:
+        raise ValueError("Rsync pull is not allowed")
+
+    resolved_root = root.expanduser().resolve()
+    target = Path(args[-1])
+    if target.is_absolute():
+        resolved_target = target.expanduser().resolve(strict=False)
+    else:
+        resolved_target = (resolved_root / target).resolve(strict=False)
+
+    try:
+        resolved_target.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError("Rsync target escapes receive root") from exc
+
+    sanitized_args = list(args)
+    sanitized_args[-1] = str(resolved_target)
+    return sanitized_args
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Restrict rsync server commands to a single receive root")
+    parser.add_argument("--root", required=True, help="Writable root for incoming rsync transfers")
+    args = parser.parse_args()
+
+    original_command = os.environ.get("SSH_ORIGINAL_COMMAND", "")
+    if not original_command:
+        print("Missing SSH_ORIGINAL_COMMAND", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        command = resolve_rsync_command(original_command, Path(args.root))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    os.execvp(command[0], command)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/src/distribute_metal_agent/runner.py
+++ b/agent/src/distribute_metal_agent/runner.py
@@ -13,6 +13,20 @@ logger = logging.getLogger(__name__)
 _active_processes: dict[str, subprocess.Popen] = {}
 
 
+def _resolve_within(root: Path, relative_path: str | None) -> Path:
+    candidate = Path(relative_path or ".")
+    if candidate.is_absolute():
+        raise ValueError(f"Path must be relative: {candidate}")
+
+    resolved_root = root.resolve()
+    resolved_path = (resolved_root / candidate).resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"Path escapes workspace root: {candidate}") from exc
+    return resolved_path
+
+
 def launch_torchrun(
     job_id: str,
     entrypoint: str,
@@ -30,7 +44,9 @@ def launch_torchrun(
     venv = d / ".venv"
     src = d / "src"
 
-    cwd = src / working_dir if working_dir else src
+    cwd = _resolve_within(src, working_dir)
+    entrypoint_path = _resolve_within(cwd, entrypoint)
+    entrypoint_arg = str(entrypoint_path.relative_to(cwd))
     log_file = d / "logs" / "torchrun.log"
 
     torchrun_bin = venv / "bin" / "torchrun"
@@ -46,7 +62,7 @@ def launch_torchrun(
         f"--node_rank={node_rank}",
         f"--master_addr={master_addr}",
         f"--master_port={master_port}",
-        entrypoint,
+        entrypoint_arg,
     ]
     if script_args:
         cmd.extend(script_args)

--- a/agent/src/distribute_metal_agent/server.py
+++ b/agent/src/distribute_metal_agent/server.py
@@ -7,26 +7,35 @@ Run with:
 """
 from __future__ import annotations
 
-import asyncio
 import logging
+import sys
 import threading
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
 
 from . import __version__
+from .bench import get_result, run_sender, start_receiver
 from .models import (
     AgentResponse,
     AgentState,
+    BenchReceiverRequest,
+    BenchReceiverResponse,
+    BenchResultResponse,
+    BenchSenderRequest,
+    BenchSenderResponse,
     CleanRequest,
+    JobInitRequest,
     LaunchRequest,
     PrepareRequest,
+    SSHAuthorizeRequest,
+    SSHAuthorizeResponse,
     StatusResponse,
     StopRequest,
 )
 from .runner import is_running, launch_torchrun, poll_exit_code, read_logs, stop_job
+from .ssh_setup import authorize_public_key, current_ssh_user, host_public_keys, rsync_available
 from .sysinfo import (
     get_arch,
     get_chip,
@@ -38,7 +47,14 @@ from .sysinfo import (
     get_uv_available,
 )
 from .auth import AuthMiddleware, load_token
-from .workspace import clean_workspace, ensure_workspace, provision_venv
+from .workspace import (
+    clean_workspace,
+    initialize_job_workspace,
+    load_job_spec,
+    promote_incoming,
+    provision_venv,
+    receive_root,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 logger = logging.getLogger("distribute-metal-agent")
@@ -62,8 +78,10 @@ if _token:
     app.add_middleware(AuthMiddleware, token=_token)
     logger.info("Authentication enabled (token loaded)")
 else:
-    logger.warning("No cluster token found. Agent is running WITHOUT authentication. "
-                   "Set DISTRIBUTE_METAL_TOKEN or create ~/.config/distribute-metal/token")
+    logger.warning(
+        "No cluster token found. Agent is running WITHOUT authentication. "
+        "Set DISTRIBUTE_METAL_TOKEN or create ~/.config/distribute-metal/token"
+    )
 
 
 @app.get("/status")
@@ -90,26 +108,45 @@ async def status() -> StatusResponse:
     )
 
 
-@app.post("/jobs/prepare")
-async def prepare(req: PrepareRequest) -> AgentResponse:
+@app.post("/jobs/init")
+async def init_job(req: JobInitRequest) -> AgentResponse:
     global state, current_job_id
 
     if state not in (AgentState.idle, AgentState.failed, AgentState.cleaned):
-        raise HTTPException(400, f"Cannot prepare: agent is {state.value}")
+        raise HTTPException(400, f"Cannot initialize job: agent is {state.value}")
 
     current_job_id = req.job_id
     state = AgentState.syncing
 
     try:
-        ensure_workspace(req.job_id)
+        initialize_job_workspace(req.job_id, req.spec)
     except Exception as exc:
         state = AgentState.failed
         return AgentResponse(ok=False, message=str(exc), state=state)
 
+    return AgentResponse(ok=True, message="Initialized for sync", state=state)
+
+
+@app.post("/jobs/prepare")
+async def prepare(req: PrepareRequest) -> AgentResponse:
+    global state, current_job_id
+
+    if current_job_id != req.job_id:
+        raise HTTPException(400, "Job ID mismatch")
+    if state != AgentState.syncing:
+        raise HTTPException(400, f"Cannot prepare: agent is {state.value}")
+
+    try:
+        promote_incoming(req.job_id)
+    except Exception as exc:
+        state = AgentState.failed
+        return AgentResponse(ok=False, message=str(exc), state=state)
+
+    state = AgentState.provisioning
+
     def _provision():
         global state
         try:
-            state = AgentState.provisioning
             provision_venv(req.job_id)
             state = AgentState.ready
         except Exception as exc:
@@ -120,7 +157,7 @@ async def prepare(req: PrepareRequest) -> AgentResponse:
     t.start()
     _provision_threads[req.job_id] = t
 
-    return AgentResponse(ok=True, message="Preparing", state=state)
+    return AgentResponse(ok=True, message="Provisioning", state=state)
 
 
 @app.post("/jobs/launch")
@@ -136,15 +173,18 @@ async def launch(req: LaunchRequest) -> AgentResponse:
     state = AgentState.launching
 
     try:
-        spec = {}  # Full spec would be loaded from workspace manifest
+        spec = load_job_spec(req.job_id)
         launch_torchrun(
             job_id=req.job_id,
-            entrypoint="train.py",
+            entrypoint=spec.project.entrypoint,
             master_addr=req.master_addr,
             master_port=req.master_port,
             world_size=req.world_size,
             node_rank=req.node_rank,
             nproc_per_node=req.nproc_per_node,
+            script_args=spec.training.torchrun.script_args,
+            env_overrides=spec.training.env,
+            working_dir=spec.project.working_dir if spec.project.working_dir != "." else None,
         )
         state = AgentState.running
         return AgentResponse(ok=True, message="Launched", state=state)
@@ -178,11 +218,66 @@ async def clean(req: CleanRequest) -> AgentResponse:
     return AgentResponse(ok=True, message="Cleaned", state=state)
 
 
+@app.post("/ssh/authorize")
+async def authorize_ssh(req: SSHAuthorizeRequest) -> SSHAuthorizeResponse:
+    authorize_public_key(
+        public_key=req.public_key,
+        key_name=req.key_name,
+        receive_root=receive_root(),
+        python_executable=sys.executable,
+    )
+    return SSHAuthorizeResponse(
+        message="SSH key authorized for push sync",
+        ssh_user=current_ssh_user(),
+        host_keys=host_public_keys(),
+        receive_root=str(receive_root()),
+        rsync_available=rsync_available(),
+    )
+
+
+def _ensure_bench_available() -> None:
+    if state in (AgentState.syncing, AgentState.provisioning, AgentState.launching, AgentState.running):
+        raise HTTPException(400, f"Cannot run benchmark while agent is {state.value}")
+
+
+@app.post("/diag/bench/receiver", response_model=BenchReceiverResponse)
+async def bench_receiver(req: BenchReceiverRequest) -> BenchReceiverResponse:
+    _ensure_bench_available()
+    try:
+        port = start_receiver(req.session_id, req.max_bytes)
+    except Exception as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return BenchReceiverResponse(session_id=req.session_id, port=port)
+
+
+@app.post("/diag/bench/sender", response_model=BenchSenderResponse)
+async def bench_sender(req: BenchSenderRequest) -> BenchSenderResponse:
+    _ensure_bench_available()
+    try:
+        return run_sender(
+            session_id=req.session_id,
+            host=req.host,
+            port=req.port,
+            bytes_to_send=req.bytes_to_send,
+            chunk_size=req.chunk_size,
+        )
+    except Exception as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+
+@app.get("/diag/bench/{session_id}", response_model=BenchResultResponse)
+async def bench_result(session_id: str) -> BenchResultResponse:
+    try:
+        return get_result(session_id)
+    except KeyError as exc:
+        raise HTTPException(404, "Benchmark session not found") from exc
+
+
 @app.put("/jobs/{job_id}/bundle")
 async def upload_bundle(job_id: str):
     """Placeholder for bundle upload. V1 expects the project to be
     pre-synced to the workspace or fetched from the coordinator file server."""
-    raise HTTPException(501, "Bundle upload not yet implemented — use coordinator file server")
+    raise HTTPException(501, "Bundle upload not implemented. Use SSH/rsync sync.")
 
 
 def main():

--- a/agent/src/distribute_metal_agent/ssh_setup.py
+++ b/agent/src/distribute_metal_agent/ssh_setup.py
@@ -1,0 +1,84 @@
+"""SSH authorization helpers for restricted rsync push access.
+
+The worker only accepts coordinator keys that are tied to a forced command,
+which delegates to ``rsync_guard`` and confines writes to the DistributeMetal
+receive root.
+"""
+
+from __future__ import annotations
+
+import getpass
+import shlex
+import shutil
+from pathlib import Path
+
+AUTHORIZED_KEYS = Path.home() / ".ssh" / "authorized_keys"
+HOST_KEY_FILES = [
+    Path("/etc/ssh/ssh_host_ed25519_key.pub"),
+    Path("/etc/ssh/ssh_host_rsa_key.pub"),
+]
+
+
+def authorize_public_key(public_key: str, key_name: str | None, receive_root: Path, python_executable: str) -> None:
+    _ = key_name
+    sanitized_key = sanitize_public_key(public_key)
+    force_command = build_force_command(receive_root, python_executable)
+    options = [
+        "restrict",
+        f'command="{force_command}"',
+    ]
+
+    entry = f"{','.join(options)} {sanitized_key}"
+
+    AUTHORIZED_KEYS.parent.mkdir(parents=True, exist_ok=True)
+    existing = AUTHORIZED_KEYS.read_text() if AUTHORIZED_KEYS.exists() else ""
+    key_body = sanitized_key.split()[1]
+    if key_body in existing:
+        return
+
+    with AUTHORIZED_KEYS.open("a", encoding="utf8") as handle:
+        if existing and not existing.endswith("\n"):
+            handle.write("\n")
+        handle.write(entry)
+        handle.write("\n")
+
+
+def build_force_command(receive_root: Path, python_executable: str) -> str:
+    return " ".join(
+        [
+            shlex.quote(python_executable),
+            "-m",
+            "distribute_metal_agent.rsync_guard",
+            "--root",
+            shlex.quote(str(receive_root)),
+        ]
+    )
+
+
+def sanitize_public_key(public_key: str) -> str:
+    sanitized = public_key.strip()
+    if "\n" in sanitized or "\r" in sanitized:
+        raise ValueError("Public key must be a single line")
+
+    parts = sanitized.split()
+    if len(parts) < 2 or parts[0] not in {"ssh-ed25519", "ssh-rsa"}:
+        raise ValueError("Only ssh-ed25519 and ssh-rsa public keys are supported")
+    return sanitized
+
+
+def current_ssh_user() -> str:
+    return getpass.getuser()
+
+
+def host_public_keys() -> list[str]:
+    keys: list[str] = []
+    for path in HOST_KEY_FILES:
+        if path.exists():
+            text = path.read_text(encoding="utf8").strip()
+            if text:
+                keys.append(text)
+    return keys
+
+
+def rsync_available() -> bool:
+    return shutil.which("rsync") is not None

--- a/agent/src/distribute_metal_agent/workspace.py
+++ b/agent/src/distribute_metal_agent/workspace.py
@@ -1,17 +1,46 @@
+"""Workspace management for the worker agent.
+
+Each job lives under ``WORKSPACE_ROOT/<job_id>``. Sync first lands in
+``incoming/`` and is only promoted into live ``src`` and ``data`` once the
+coordinator has finished pushing files for that job.
+"""
+
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 import subprocess
 from pathlib import Path
 
+from .models import JobSpec
+
 logger = logging.getLogger(__name__)
 
 WORKSPACE_ROOT = Path.home() / "Library" / "Application Support" / "DistributeMetal" / "jobs"
+SPEC_FILE = "job_spec.json"
+INCOMING_DIR = "incoming"
 
 
 def job_dir(job_id: str) -> Path:
     return WORKSPACE_ROOT / job_id
+
+
+def receive_root() -> Path:
+    WORKSPACE_ROOT.mkdir(parents=True, exist_ok=True)
+    return WORKSPACE_ROOT
+
+
+def incoming_dir(job_id: str) -> Path:
+    return job_dir(job_id) / INCOMING_DIR
+
+
+def incoming_src_dir(job_id: str) -> Path:
+    return incoming_dir(job_id) / "src"
+
+
+def incoming_data_dir(job_id: str) -> Path:
+    return incoming_dir(job_id) / "data"
 
 
 def ensure_workspace(job_id: str) -> Path:
@@ -20,6 +49,53 @@ def ensure_workspace(job_id: str) -> Path:
     (d / "data").mkdir(exist_ok=True)
     (d / "logs").mkdir(exist_ok=True)
     return d
+
+
+def initialize_job_workspace(job_id: str, spec: JobSpec) -> Path:
+    d = ensure_workspace(job_id)
+    incoming = incoming_dir(job_id)
+    if incoming.exists():
+        shutil.rmtree(incoming)
+    incoming_src_dir(job_id).mkdir(parents=True, exist_ok=True)
+    incoming_data_dir(job_id).mkdir(parents=True, exist_ok=True)
+    save_job_spec(job_id, spec)
+    return d
+
+
+def save_job_spec(job_id: str, spec: JobSpec) -> None:
+    d = ensure_workspace(job_id)
+    (d / SPEC_FILE).write_text(spec.model_dump_json(indent=2), encoding="utf8")
+
+
+def load_job_spec(job_id: str) -> JobSpec:
+    spec_path = job_dir(job_id) / SPEC_FILE
+    if not spec_path.exists():
+        raise FileNotFoundError(f"No job spec found for {job_id}")
+    return JobSpec.model_validate(json.loads(spec_path.read_text(encoding="utf8")))
+
+
+def promote_incoming(job_id: str) -> None:
+    d = ensure_workspace(job_id)
+    incoming_src = incoming_src_dir(job_id)
+    if not incoming_src.exists():
+        raise FileNotFoundError(f"No synced source found in {incoming_src}")
+
+    incoming_data = incoming_data_dir(job_id)
+
+    for subdir in ["src", "data"]:
+        path = d / subdir
+        if path.exists():
+            shutil.rmtree(path)
+
+    incoming_src.rename(d / "src")
+    if incoming_data.exists():
+        incoming_data.rename(d / "data")
+    else:
+        (d / "data").mkdir(parents=True, exist_ok=True)
+
+    incoming = incoming_dir(job_id)
+    if incoming.exists():
+        shutil.rmtree(incoming)
 
 
 def provision_venv(job_id: str) -> None:
@@ -66,10 +142,13 @@ def clean_workspace(job_id: str, keep_logs: bool = True) -> None:
     if not d.exists():
         return
 
-    for sub in ["src", ".venv", "data"]:
+    for sub in ["src", ".venv", "data", INCOMING_DIR, SPEC_FILE]:
         p = d / sub
         if p.exists():
-            shutil.rmtree(p)
+            if p.is_dir():
+                shutil.rmtree(p)
+            else:
+                p.unlink()
             logger.info("Removed %s", p)
 
     if not keep_logs:

--- a/agent/tests/test_rsync_guard.py
+++ b/agent/tests/test_rsync_guard.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+from distribute_metal_agent.rsync_guard import resolve_rsync_command
+
+
+@pytest.mark.unit
+def test_resolve_rsync_command_allows_push_within_receive_root(tmp_path: Path) -> None:
+    command = "rsync --server -logDtpre.iLsfxCIvu . job-123/incoming/src/"
+
+    resolved = resolve_rsync_command(command, tmp_path)
+
+    assert resolved[0] == "rsync"
+    assert resolved[-1] == str((tmp_path / "job-123/incoming/src").resolve(strict=False))
+
+
+@pytest.mark.unit
+def test_resolve_rsync_command_rejects_sender_mode(tmp_path: Path) -> None:
+    command = "rsync --server --sender -logDtpre.iLsfxCIvu . job-123/incoming/src/"
+
+    with pytest.raises(ValueError, match="pull"):
+        resolve_rsync_command(command, tmp_path)
+
+
+@pytest.mark.unit
+def test_resolve_rsync_command_rejects_escape(tmp_path: Path) -> None:
+    command = "rsync --server -logDtpre.iLsfxCIvu . ../secret"
+
+    with pytest.raises(ValueError, match="escapes receive root"):
+        resolve_rsync_command(command, tmp_path)

--- a/agent/tests/test_runner_paths.py
+++ b/agent/tests/test_runner_paths.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from distribute_metal_agent.runner import _resolve_within
+
+
+@pytest.mark.unit
+def test_resolve_within_allows_relative_path(tmp_path: Path) -> None:
+    resolved = _resolve_within(tmp_path, "src/train.py")
+    assert resolved == (tmp_path / "src/train.py").resolve(strict=False)
+
+
+@pytest.mark.unit
+def test_resolve_within_rejects_escape(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        _resolve_within(tmp_path, "../outside.py")
+
+
+@pytest.mark.unit
+def test_resolve_within_rejects_absolute_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="relative"):
+        _resolve_within(tmp_path, "/tmp/outside.py")

--- a/apps/DistributeMetal/Models/AgentAPI.swift
+++ b/apps/DistributeMetal/Models/AgentAPI.swift
@@ -37,13 +37,21 @@ struct AgentStatusResponse: Codable {
     }
 }
 
-struct PrepareRequest: Codable {
+struct JobInitRequest: Codable {
     var jobId: String
     var spec: JobSpec
 
     enum CodingKeys: String, CodingKey {
         case jobId = "job_id"
         case spec
+    }
+}
+
+struct PrepareRequest: Codable {
+    var jobId: String
+
+    enum CodingKeys: String, CodingKey {
+        case jobId = "job_id"
     }
 }
 
@@ -69,4 +77,106 @@ struct AgentResponse: Codable {
     var ok: Bool
     var message: String?
     var state: AgentState?
+}
+
+struct SSHAuthorizeRequest: Codable {
+    var publicKey: String
+    var keyName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case publicKey = "public_key"
+        case keyName = "key_name"
+    }
+}
+
+struct SSHAuthorizeResponse: Codable {
+    var ok: Bool
+    var message: String?
+    var sshUser: String
+    var hostKeys: [String]
+    var receiveRoot: String
+    var rsyncAvailable: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case ok, message
+        case sshUser = "ssh_user"
+        case hostKeys = "host_keys"
+        case receiveRoot = "receive_root"
+        case rsyncAvailable = "rsync_available"
+    }
+}
+
+struct BenchReceiverRequest: Codable {
+    var sessionId: String
+    var maxBytes: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case maxBytes = "max_bytes"
+    }
+}
+
+struct BenchReceiverResponse: Codable {
+    var sessionId: String
+    var port: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case port
+    }
+}
+
+struct BenchSenderRequest: Codable {
+    var sessionId: String
+    var host: String
+    var port: Int
+    var bytesToSend: Int
+    var chunkSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case host, port
+        case bytesToSend = "bytes_to_send"
+        case chunkSize = "chunk_size"
+    }
+}
+
+struct BenchSenderResponse: Codable {
+    var sessionId: String
+    var bytesSent: Int
+    var durationSeconds: Double
+    var throughputMbps: Double
+    var connectLatencyMs: Double
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case bytesSent = "bytes_sent"
+        case durationSeconds = "duration_seconds"
+        case throughputMbps = "throughput_mbps"
+        case connectLatencyMs = "connect_latency_ms"
+    }
+}
+
+enum BenchResultState: String, Codable {
+    case pending
+    case completed
+    case failed
+}
+
+struct BenchResultResponse: Codable {
+    var sessionId: String
+    var state: BenchResultState
+    var bytesReceived: Int
+    var durationSeconds: Double?
+    var throughputMbps: Double?
+    var error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case state
+        case bytesReceived = "bytes_received"
+        case durationSeconds = "duration_seconds"
+        case throughputMbps = "throughput_mbps"
+        case error
+    }
 }

--- a/apps/DistributeMetal/Models/Peer.swift
+++ b/apps/DistributeMetal/Models/Peer.swift
@@ -2,11 +2,10 @@ import Foundation
 
 enum PeerStatus: String, Codable {
     case discovered
-    case paired
-    case preflight
+    case unreachable
+    case agentFailed
     case ready
     case busy
-    case offline
 }
 
 struct Peer: Identifiable, Codable, Hashable {
@@ -26,10 +25,30 @@ struct Peer: Identifiable, Codable, Hashable {
     var pythonVersion: String?
     var uvAvailable: Bool?
     var freeDiskGB: Double?
+    var statusDetail: String?
+    var sshUser: String?
+    var receiveRoot: String?
+    var sshConfigured: Bool = false
+    var lastBenchmarkMbps: Double?
+    var lastBenchmarkLatencyMs: Double?
 
     var lastSeen: Date
 
     var displayAddress: String { "\(ipAddress):\(port)" }
+    var statusLabel: String {
+        switch status {
+        case .discovered:
+            return "discovered"
+        case .unreachable:
+            return "unreachable"
+        case .agentFailed:
+            return "agent failed"
+        case .ready:
+            return "ready"
+        case .busy:
+            return "busy"
+        }
+    }
 
     static func manual(name: String, ip: String, port: Int = 8477) -> Peer {
         Peer(

--- a/apps/DistributeMetal/Services/AgentClient.swift
+++ b/apps/DistributeMetal/Services/AgentClient.swift
@@ -1,6 +1,27 @@
 import Foundation
 import os.log
 
+enum AgentClientError: LocalizedError {
+    case invalidResponse
+    case httpStatus(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "The agent returned an invalid response."
+        case .httpStatus(let code, let body):
+            if body.isEmpty {
+                return "The agent returned HTTP \(code)."
+            }
+            return "The agent returned HTTP \(code): \(body)"
+        }
+    }
+}
+
+/// Thin HTTP client for the worker agent API.
+///
+/// The bearer token is read from the same environment variable or token file as
+/// the menu bar app and MCP integration, so the control plane stays aligned.
 actor AgentClient {
     private let logger = Logger(subsystem: "one.measured.distribute-metal", category: "AgentClient")
     private let session: URLSession
@@ -46,68 +67,129 @@ actor AgentClient {
     // MARK: - Status
 
     func fetchStatus(from peer: Peer) async throws -> AgentStatusResponse {
-        let (data, _) = try await session.data(from: url(for: peer, path: "/status"))
-        return try JSONDecoder().decode(AgentStatusResponse.self, from: data)
+        try await request(peer: peer, path: "/status", method: "GET")
+    }
+
+    // MARK: - Job init
+
+    func initializeJob(peer: Peer, jobId: String, spec: JobSpec) async throws -> AgentResponse {
+        let req = JobInitRequest(jobId: jobId, spec: spec)
+        return try await request(peer: peer, path: "/jobs/init", method: "POST", body: req)
     }
 
     // MARK: - Prepare (send job spec, trigger bundle sync + venv provision)
 
-    func prepare(peer: Peer, jobId: String, spec: JobSpec) async throws -> AgentResponse {
-        let req = PrepareRequest(jobId: jobId, spec: spec)
-        return try await post(peer: peer, path: "/jobs/prepare", body: req)
+    func prepare(peer: Peer, jobId: String) async throws -> AgentResponse {
+        let req = PrepareRequest(jobId: jobId)
+        return try await request(peer: peer, path: "/jobs/prepare", method: "POST", body: req)
     }
 
     // MARK: - Launch (start torchrun with assigned rank)
 
     func launch(peer: Peer, request: LaunchRequest) async throws -> AgentResponse {
-        return try await post(peer: peer, path: "/jobs/launch", body: request)
+        try await self.request(peer: peer, path: "/jobs/launch", method: "POST", body: request)
     }
 
     // MARK: - Stop
 
     func stop(peer: Peer, jobId: String) async throws -> AgentResponse {
         let body = ["job_id": jobId]
-        return try await post(peer: peer, path: "/jobs/stop", body: body)
+        return try await request(peer: peer, path: "/jobs/stop", method: "POST", body: body)
     }
 
     // MARK: - Clean
 
     func clean(peer: Peer, jobId: String) async throws -> AgentResponse {
         let body = ["job_id": jobId]
-        return try await post(peer: peer, path: "/jobs/clean", body: body)
+        return try await request(peer: peer, path: "/jobs/clean", method: "POST", body: body)
     }
 
     // MARK: - Logs
 
     func fetchLogs(from peer: Peer, jobId: String, tail: Int = 200) async throws -> [String] {
-        let (data, _) = try await session.data(
-            from: url(for: peer, path: "/jobs/\(jobId)/logs?tail=\(tail)")
-        )
-        return try JSONDecoder().decode([String].self, from: data)
+        try await request(peer: peer, path: "/jobs/\(jobId)/logs?tail=\(tail)", method: "GET")
+    }
+
+    // MARK: - SSH sync setup
+
+    func authorizeSSH(peer: Peer, publicKey: String, keyName: String) async throws -> SSHAuthorizeResponse {
+        let req = SSHAuthorizeRequest(publicKey: publicKey, keyName: keyName)
+        return try await request(peer: peer, path: "/ssh/authorize", method: "POST", body: req)
+    }
+
+    // MARK: - Benchmarks
+
+    func startBenchmarkReceiver(peer: Peer, sessionId: String, maxBytes: Int) async throws -> BenchReceiverResponse {
+        let req = BenchReceiverRequest(sessionId: sessionId, maxBytes: maxBytes)
+        return try await request(peer: peer, path: "/diag/bench/receiver", method: "POST", body: req)
+    }
+
+    func runBenchmarkSender(peer: Peer, request: BenchSenderRequest) async throws -> BenchSenderResponse {
+        try await self.request(peer: peer, path: "/diag/bench/sender", method: "POST", body: request)
+    }
+
+    func fetchBenchmarkResult(peer: Peer, sessionId: String) async throws -> BenchResultResponse {
+        try await request(peer: peer, path: "/diag/bench/\(sessionId)", method: "GET")
     }
 
     // MARK: - Upload bundle archive
 
     func uploadBundle(to peer: Peer, jobId: String, archiveURL: URL) async throws -> AgentResponse {
-        var request = URLRequest(url: url(for: peer, path: "/jobs/\(jobId)/bundle"))
-        request.httpMethod = "PUT"
-        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        var urlRequest = URLRequest(url: url(for: peer, path: "/jobs/\(jobId)/bundle"))
+        urlRequest.httpMethod = "PUT"
+        urlRequest.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        if let token { urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
-        let (data, _) = try await session.upload(for: request, fromFile: archiveURL)
+        let (data, response) = try await session.upload(for: urlRequest, fromFile: archiveURL)
+        try validate(response: response, data: data)
         return try JSONDecoder().decode(AgentResponse.self, from: data)
     }
 
     // MARK: - Helpers
 
-    private func post<T: Encodable>(peer: Peer, path: String, body: T) async throws -> AgentResponse {
-        var request = URLRequest(url: url(for: peer, path: path))
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
-        request.httpBody = try JSONEncoder().encode(body)
+    private func request<Response: Decodable>(
+        peer: Peer,
+        path: String,
+        method: String
+    ) async throws -> Response {
+        var urlRequest = URLRequest(url: url(for: peer, path: path))
+        urlRequest.httpMethod = method
+        if let token {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
 
-        let (data, _) = try await session.data(for: request)
-        return try JSONDecoder().decode(AgentResponse.self, from: data)
+        let (data, response) = try await session.data(for: urlRequest)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+
+    private func request<RequestBody: Encodable, Response: Decodable>(
+        peer: Peer,
+        path: String,
+        method: String,
+        body: RequestBody
+    ) async throws -> Response {
+        var urlRequest = URLRequest(url: url(for: peer, path: path))
+        urlRequest.httpMethod = method
+        if let token {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: urlRequest)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw AgentClientError.invalidResponse
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            logger.error("Agent request failed with HTTP \(http.statusCode, privacy: .public)")
+            throw AgentClientError.httpStatus(http.statusCode, body)
+        }
     }
 }

--- a/apps/DistributeMetal/Services/DiscoveryService.swift
+++ b/apps/DistributeMetal/Services/DiscoveryService.swift
@@ -3,6 +3,11 @@ import Network
 import Combine
 import os.log
 
+/// Tracks Bonjour-visible peers, probes the agent on each peer, and records
+/// link benchmark results for the menu bar UI.
+///
+/// Discovery keys peers by either TXT-provided IP or Bonjour hostname so a row
+/// can survive transitions from hostname-only discovery to a concrete address.
 @MainActor
 final class DiscoveryService: ObservableObject {
     static let shared = DiscoveryService()
@@ -13,6 +18,7 @@ final class DiscoveryService: ObservableObject {
 
     @Published var discoveredPeers: [String: Peer] = [:]
     @Published var isScanning = false
+    @Published var benchmarkingPeerIDs: Set<UUID> = []
 
     private var browser: NWBrowser?
     private var localBrowser: NWBrowser?
@@ -130,23 +136,9 @@ final class DiscoveryService: ObservableObject {
                     group.addTask { [client] in
                         do {
                             let status = try await client.fetchStatus(from: peer)
-                            var updated = peer
-                            updated.status = Self.mapAgentState(status.state)
-                            updated.arch = status.arch
-                            updated.chip = status.chip
-                            updated.memoryGB = status.memoryGB
-                            updated.macOSVersion = status.macOSVersion
-                            updated.agentVersion = status.agentVersion
-                            updated.mcclVersion = status.mcclVersion
-                            updated.pythonVersion = status.pythonVersion
-                            updated.uvAvailable = status.uvAvailable
-                            updated.freeDiskGB = status.freeDiskGB
-                            updated.lastSeen = Date()
-                            return (ip, updated)
+                            return (ip, Self.updatedPeer(from: status, peer: peer))
                         } catch {
-                            var updated = peer
-                            updated.status = .offline
-                            return (ip, updated)
+                            return (ip, Self.unreachablePeer(from: peer, error: error))
                         }
                     }
                 }
@@ -162,23 +154,9 @@ final class DiscoveryService: ObservableObject {
     func probePeer(_ peer: Peer) async -> Peer {
         do {
             let status = try await client.fetchStatus(from: peer)
-            var updated = peer
-            updated.status = Self.mapAgentState(status.state)
-            updated.arch = status.arch
-            updated.chip = status.chip
-            updated.memoryGB = status.memoryGB
-            updated.macOSVersion = status.macOSVersion
-            updated.agentVersion = status.agentVersion
-            updated.mcclVersion = status.mcclVersion
-            updated.pythonVersion = status.pythonVersion
-            updated.uvAvailable = status.uvAvailable
-            updated.freeDiskGB = status.freeDiskGB
-            updated.lastSeen = Date()
-            return updated
+            return Self.updatedPeer(from: status, peer: peer)
         } catch {
-            var updated = peer
-            updated.status = .offline
-            return updated
+            return Self.unreachablePeer(from: peer, error: error)
         }
     }
 
@@ -189,8 +167,53 @@ final class DiscoveryService: ObservableObject {
         case .syncing, .provisioning, .launching, .running:
             return .busy
         case .failed:
-            return .offline
+            return .agentFailed
         }
+    }
+
+    private nonisolated static func updatedPeer(from status: AgentStatusResponse, peer: Peer) -> Peer {
+        var updated = peer
+        updated.status = mapAgentState(status.state)
+        updated.arch = status.arch
+        updated.chip = status.chip
+        updated.memoryGB = status.memoryGB
+        updated.macOSVersion = status.macOSVersion
+        updated.agentVersion = status.agentVersion
+        updated.mcclVersion = status.mcclVersion
+        updated.pythonVersion = status.pythonVersion
+        updated.uvAvailable = status.uvAvailable
+        updated.freeDiskGB = status.freeDiskGB
+        updated.statusDetail = status.state == .failed ? "agent reported failure" : nil
+        updated.lastSeen = Date()
+        return updated
+    }
+
+    private nonisolated static func unreachablePeer(from peer: Peer, error: Error) -> Peer {
+        var updated = peer
+        updated.status = .unreachable
+        updated.statusDetail = probeFailureDescription(error)
+        return updated
+    }
+
+    private nonisolated static func probeFailureDescription(_ error: Error) -> String {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .cannotConnectToHost:
+                return "cannot connect to agent"
+            case .timedOut:
+                return "agent probe timed out"
+            case .notConnectedToInternet:
+                return "network unavailable"
+            case .networkConnectionLost:
+                return "network connection lost"
+            default:
+                return urlError.localizedDescription
+            }
+        }
+        if let clientError = error as? AgentClientError {
+            return clientError.localizedDescription
+        }
+        return error.localizedDescription
     }
 
     private func normalizedAddress(_ address: String?) -> String? {
@@ -256,6 +279,7 @@ final class DiscoveryService: ObservableObject {
         current.pythonVersion = probed.pythonVersion ?? current.pythonVersion
         current.uvAvailable = probed.uvAvailable ?? current.uvAvailable
         current.freeDiskGB = probed.freeDiskGB ?? current.freeDiskGB
+        current.statusDetail = probed.statusDetail
         current.lastSeen = probed.lastSeen
         return current
     }
@@ -285,7 +309,7 @@ final class DiscoveryService: ObservableObject {
             let previousPeer = discoveredPeers[previousKey]
             let shouldProbe = previousPeer == nil
                 || previousPeer?.ipAddress != address
-                || previousPeer?.status == .offline
+                || previousPeer?.status == .unreachable
 
             var peer = previousPeer ?? Peer(
                 id: UUID(),
@@ -338,6 +362,90 @@ final class DiscoveryService: ObservableObject {
 
     func removePeer(ip: String) {
         discoveredPeers.removeValue(forKey: peerKey(for: ip))
+    }
+
+    func updatePeer(_ peer: Peer) {
+        let key = existingPeerKey(
+            for: peer.hostname,
+            ip: normalizedAddress(peer.ipAddress)
+        ) ?? peerKey(for: peer.ipAddress)
+        discoveredPeers[key] = peer
+    }
+
+    /// Runs a bidirectional worker-to-worker benchmark between the local agent
+    /// and the selected peer. The stored throughput keeps the slower direction,
+    /// which is the useful number when the link is asymmetric.
+    func benchmarkPeer(_ peer: Peer) async throws {
+        guard let localIP = normalizedAddress(NetworkUtils.localIPAddress) else {
+            throw NSError(domain: "DiscoveryService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Local IP address is unavailable"])
+        }
+
+        benchmarkingPeerIDs.insert(peer.id)
+        defer { benchmarkingPeerIDs.remove(peer.id) }
+
+        let localPeer = Peer.manual(name: NetworkUtils.sanitizedComputerName, ip: "127.0.0.1", port: Int(agentPort.rawValue))
+        let bytes = 128 * 1024 * 1024
+
+        let forwardSession = UUID().uuidString
+        let forwardReceiver = try await client.startBenchmarkReceiver(peer: localPeer, sessionId: forwardSession, maxBytes: bytes)
+        let forwardSender = try await client.runBenchmarkSender(
+            peer: peer,
+            request: BenchSenderRequest(
+                sessionId: forwardSession,
+                host: localIP,
+                port: forwardReceiver.port,
+                bytesToSend: bytes,
+                chunkSize: 1024 * 1024
+            )
+        )
+        let forwardResult = try await waitForBenchmarkResult(peer: localPeer, sessionId: forwardSession)
+
+        let reverseSession = UUID().uuidString
+        let reverseReceiver = try await client.startBenchmarkReceiver(peer: peer, sessionId: reverseSession, maxBytes: bytes)
+        let reverseSender = try await client.runBenchmarkSender(
+            peer: localPeer,
+            request: BenchSenderRequest(
+                sessionId: reverseSession,
+                host: peer.ipAddress,
+                port: reverseReceiver.port,
+                bytesToSend: bytes,
+                chunkSize: 1024 * 1024
+            )
+        )
+        let reverseResult = try await waitForBenchmarkResult(peer: peer, sessionId: reverseSession)
+
+        var updated = peer
+        updated.lastBenchmarkMbps = min(
+            forwardResult.throughputMbps ?? forwardSender.throughputMbps,
+            reverseResult.throughputMbps ?? reverseSender.throughputMbps
+        )
+        updated.lastBenchmarkLatencyMs = (forwardSender.connectLatencyMs + reverseSender.connectLatencyMs) / 2
+        updatePeer(updated)
+    }
+
+    private func waitForBenchmarkResult(peer: Peer, sessionId: String) async throws -> BenchResultResponse {
+        let deadline = Date().addingTimeInterval(45)
+        while Date() < deadline {
+            let result = try await client.fetchBenchmarkResult(peer: peer, sessionId: sessionId)
+            switch result.state {
+            case .pending:
+                try await Task.sleep(for: .milliseconds(250))
+            case .completed:
+                return result
+            case .failed:
+                throw NSError(
+                    domain: "DiscoveryService",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: result.error ?? "benchmark failed"]
+                )
+            }
+        }
+
+        throw NSError(
+            domain: "DiscoveryService",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for benchmark result"]
+        )
     }
 }
 

--- a/apps/DistributeMetal/Services/JobOrchestrator.swift
+++ b/apps/DistributeMetal/Services/JobOrchestrator.swift
@@ -2,12 +2,19 @@ import Foundation
 import os.log
 import Combine
 
+/// Coordinates the worker lifecycle for a single job.
+///
+/// The run sequence is: authorize restricted SSH push access, initialize worker
+/// workspaces, rsync the staged project and data, prepare/provision, poll until
+/// ready, then launch `torchrun` with rank-specific parameters.
 @MainActor
 final class JobOrchestrator: ObservableObject {
     static let shared = JobOrchestrator()
 
     private let logger = Logger(subsystem: "one.measured.distribute-metal", category: "Orchestrator")
     private let client = AgentClient()
+    private let sshService = SSHService.shared
+    private let syncService = RsyncService.shared
 
     @Published var currentJob: Job?
     @Published var jobHistory: [Job] = []
@@ -40,39 +47,29 @@ final class JobOrchestrator: ObservableObject {
             logger.error("No current job to run")
             return
         }
-
-        let masterPeer = job.assignedPeers[0]
-        let masterAddr = masterPeer.ipAddress
-        let masterPort = job.spec.training.torchrun.masterPort ?? 29500
+        guard !job.assignedPeers.isEmpty else {
+            logger.error("No peers assigned to job")
+            appendLog("Job failed: no peers assigned.")
+            return
+        }
 
         do {
-            // Phase: prepare all peers
+            // Phase: initialize sync + prepare all peers
             job.phase = .syncing
             currentJob = job
-            appendLog("Preparing \(job.assignedPeers.count) peers...")
+            appendLog("Initializing secure sync for \(job.assignedPeers.count) peer(s)...")
 
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                for peer in job.assignedPeers {
-                    group.addTask {
-                        let resp = try await self.client.prepare(
-                            peer: peer,
-                            jobId: job.id.uuidString,
-                            spec: job.spec
-                        )
-                        if !resp.ok {
-                            throw OrchestratorError.prepareFailed(peer: peer.name, message: resp.message ?? "unknown")
-                        }
-                    }
-                }
-                try await group.waitForAll()
-            }
+            let preparedPeers = try await preparePeersForRun(job: job)
+            job.assignedPeers = preparedPeers
+            job.masterPeer = preparedPeers.first
+            currentJob = job
 
             appendLog("All peers prepared. Waiting for ready state...")
 
             // Phase: wait for all peers to be ready (provisioned)
             job.phase = .provisioning
             currentJob = job
-            try await waitForAllReady(peers: job.assignedPeers, jobId: job.id.uuidString, timeout: 300)
+            try await waitForAllReady(peers: preparedPeers, jobId: job.id.uuidString, timeout: 300)
 
             // Phase: barriered launch
             job.phase = .launching
@@ -80,8 +77,12 @@ final class JobOrchestrator: ObservableObject {
             currentJob = job
             appendLog("Launching torchrun across \(job.worldSize) rank(s)...")
 
+            let masterPeer = preparedPeers[0]
+            let masterAddr = masterPeer.ipAddress
+            let masterPort = job.spec.training.torchrun.masterPort ?? 29500
+
             try await withThrowingTaskGroup(of: Void.self) { group in
-                for (idx, peer) in job.assignedPeers.enumerated() {
+                for (idx, peer) in preparedPeers.enumerated() {
                     let req = LaunchRequest(
                         jobId: job.id.uuidString,
                         masterAddr: masterAddr,
@@ -155,6 +156,57 @@ final class JobOrchestrator: ObservableObject {
 
     // MARK: - Helpers
 
+    private func preparePeersForRun(job: Job) async throws -> [Peer] {
+        let client = self.client
+        let sshService = self.sshService
+        let syncService = self.syncService
+
+        return try await withThrowingTaskGroup(of: Peer.self) { group in
+            for peer in job.assignedPeers {
+                group.addTask {
+                    let preparedPeer = try await sshService.configurePushAccess(for: peer, client: client)
+                    await MainActor.run {
+                        DiscoveryService.shared.updatePeer(preparedPeer)
+                    }
+
+                    let initResponse = try await client.initializeJob(
+                        peer: preparedPeer,
+                        jobId: job.id.uuidString,
+                        spec: job.spec
+                    )
+                    if !initResponse.ok {
+                        throw OrchestratorError.syncFailed(peer: peer.name, message: initResponse.message ?? "job init failed")
+                    }
+
+                    try syncService.sync(job: job, to: preparedPeer)
+
+                    let prepareResponse = try await client.prepare(
+                        peer: preparedPeer,
+                        jobId: job.id.uuidString
+                    )
+                    if !prepareResponse.ok {
+                        throw OrchestratorError.prepareFailed(peer: peer.name, message: prepareResponse.message ?? "prepare failed")
+                    }
+
+                    await MainActor.run {
+                        DiscoveryService.shared.updatePeer(preparedPeer)
+                    }
+                    return preparedPeer
+                }
+            }
+
+            var preparedPeers: [Peer] = []
+            for try await peer in group {
+                preparedPeers.append(peer)
+            }
+
+            let order = job.assignedPeers.map(\.id)
+            return preparedPeers.sorted { left, right in
+                order.firstIndex(of: left.id) ?? 0 < order.firstIndex(of: right.id) ?? 0
+            }
+        }
+    }
+
     private func waitForAllReady(peers: [Peer], jobId: String, timeout: TimeInterval) async throws {
         let deadline = Date().addingTimeInterval(timeout)
 
@@ -184,6 +236,7 @@ final class JobOrchestrator: ObservableObject {
 }
 
 enum OrchestratorError: LocalizedError {
+    case syncFailed(peer: String, message: String)
     case prepareFailed(peer: String, message: String)
     case launchFailed(peer: String, message: String)
     case peerFailed(peer: String)
@@ -191,6 +244,7 @@ enum OrchestratorError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .syncFailed(let p, let m): return "Sync failed on \(p): \(m)"
         case .prepareFailed(let p, let m): return "Prepare failed on \(p): \(m)"
         case .launchFailed(let p, let m): return "Launch failed on \(p): \(m)"
         case .peerFailed(let p): return "Peer \(p) entered failed state"

--- a/apps/DistributeMetal/Services/RsyncService.swift
+++ b/apps/DistributeMetal/Services/RsyncService.swift
@@ -1,0 +1,244 @@
+import Foundation
+import os.log
+
+enum RsyncServiceError: LocalizedError {
+    case sshNotConfigured(String)
+    case invalidProjectRoot(String)
+    case invalidDataPath(String)
+    case missingLocalPath(String)
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sshNotConfigured(let peer):
+            return "SSH push sync is not configured for \(peer)."
+        case .invalidProjectRoot(let path):
+            return "Invalid project root: \(path)"
+        case .invalidDataPath(let path):
+            return "Invalid data path in sync spec: \(path)"
+        case .missingLocalPath(let path):
+            return "Missing local path for sync: \(path)"
+        case .commandFailed(let message):
+            return message
+        }
+    }
+}
+
+/// Pushes a filtered project snapshot from the coordinator to a worker job
+/// workspace over rsync + SSH.
+///
+/// Filter order matters here: forced secret excludes win first, then user
+/// excludes, then include rules, then a final `--exclude=*` closes the tree.
+final class RsyncService {
+    static let shared = RsyncService()
+
+    private let logger = Logger(subsystem: "one.measured.distribute-metal", category: "RsyncService")
+    private let sshService = SSHService.shared
+    private let fileManager = FileManager.default
+    private let forcedExcludes = [
+        ".env",
+        ".env.*",
+        ".ssh/**",
+        "**/.env",
+        "**/.env.*",
+        "**/*.pem",
+        "**/*.key",
+        "**/*.p12"
+    ]
+
+    private init() {}
+
+    func sync(job: Job, to peer: Peer) throws {
+        guard peer.sshConfigured,
+              let sshUser = peer.sshUser else {
+            throw RsyncServiceError.sshNotConfigured(peer.name)
+        }
+
+        let identityURL = try sshService.privateKeyURL(for: peer)
+        let knownHostsURL = try sshService.knownHostsURL()
+        let projectRoot = try resolvedProjectRoot(for: job)
+
+        try syncProject(
+            projectRoot: projectRoot,
+            include: job.spec.project.include,
+            exclude: job.spec.project.exclude,
+            remoteTarget: "\(job.id.uuidString)/incoming/src/",
+            sshUser: sshUser,
+            peer: peer,
+            identityURL: identityURL,
+            knownHostsURL: knownHostsURL
+        )
+
+        for entry in job.spec.data where shouldPushData(entry) {
+            try syncDataEntry(
+                entry: entry,
+                projectRoot: projectRoot,
+                remoteBase: "\(job.id.uuidString)/incoming/data/",
+                sshUser: sshUser,
+                peer: peer,
+                identityURL: identityURL,
+                knownHostsURL: knownHostsURL
+            )
+        }
+    }
+
+    private func shouldPushData(_ entry: JobSpec.DataSpec) -> Bool {
+        let source = entry.source.lowercased()
+        return source == "coordinator" || source == "local"
+    }
+
+    private func resolvedProjectRoot(for job: Job) throws -> URL {
+        let root = job.sourcePath.appendingPathComponent(job.spec.project.root)
+        let standardized = root.standardizedFileURL
+        guard standardized.path.hasPrefix(job.sourcePath.standardizedFileURL.path) else {
+            throw RsyncServiceError.invalidProjectRoot(job.spec.project.root)
+        }
+        guard fileManager.fileExists(atPath: standardized.path) else {
+            throw RsyncServiceError.missingLocalPath(standardized.path)
+        }
+        return standardized
+    }
+
+    private func syncProject(
+        projectRoot: URL,
+        include: [String],
+        exclude: [String],
+        remoteTarget: String,
+        sshUser: String,
+        peer: Peer,
+        identityURL: URL,
+        knownHostsURL: URL
+    ) throws {
+        var arguments = [
+            "-a",
+            "--delete",
+            "--prune-empty-dirs",
+            "-e", sshCommand(identityURL: identityURL, knownHostsURL: knownHostsURL)
+        ]
+
+        for pattern in forcedExcludes {
+            arguments.append("--exclude=\(pattern)")
+        }
+        for pattern in exclude {
+            arguments.append("--exclude=\(pattern)")
+        }
+        arguments.append("--include=*/")
+        for pattern in include {
+            arguments.append("--include=\(pattern)")
+        }
+        arguments.append("--exclude=*")
+        arguments.append("./")
+        arguments.append("\(sshUser)@\(peer.ipAddress):\(remoteTarget)")
+
+        try run(
+            executable: "/usr/bin/rsync",
+            arguments: arguments,
+            currentDirectoryURL: projectRoot
+        )
+    }
+
+    private func syncDataEntry(
+        entry: JobSpec.DataSpec,
+        projectRoot: URL,
+        remoteBase: String,
+        sshUser: String,
+        peer: Peer,
+        identityURL: URL,
+        knownHostsURL: URL
+    ) throws {
+        let normalized = try normalizeRelativePath(entry.path)
+        let localRoot: URL
+        let relativeSource: String
+        let useRelative = normalized != "."
+
+        if normalized == "data" || normalized.hasPrefix("data/") {
+            localRoot = projectRoot.appendingPathComponent("data", isDirectory: true)
+            let suffix = normalized == "data" ? "" : String(normalized.dropFirst("data/".count))
+            relativeSource = suffix.isEmpty ? "./" : "./\(suffix)"
+        } else {
+            localRoot = projectRoot
+            relativeSource = "./\(normalized)"
+        }
+
+        let resolvedPath = localRoot.appendingPathComponent(relativeSource.replacingOccurrences(of: "./", with: ""))
+            .standardizedFileURL
+        guard resolvedPath.path.hasPrefix(projectRoot.path) else {
+            throw RsyncServiceError.invalidDataPath(entry.path)
+        }
+        guard fileManager.fileExists(atPath: resolvedPath.path) else {
+            throw RsyncServiceError.missingLocalPath(resolvedPath.path)
+        }
+
+        var arguments = [
+            "-a",
+            "--delete",
+            "-e", sshCommand(identityURL: identityURL, knownHostsURL: knownHostsURL)
+        ]
+        if useRelative {
+            arguments.append("-R")
+        }
+        arguments.append(relativeSource)
+        arguments.append("\(sshUser)@\(peer.ipAddress):\(remoteBase)")
+
+        try run(
+            executable: "/usr/bin/rsync",
+            arguments: arguments,
+            currentDirectoryURL: localRoot
+        )
+    }
+
+    private func sshCommand(identityURL: URL, knownHostsURL: URL) -> String {
+        [
+            "/usr/bin/ssh",
+            "-i", shellQuote(identityURL.path),
+            "-o", "IdentitiesOnly=yes",
+            "-o", "StrictHostKeyChecking=yes",
+            "-o", "UserKnownHostsFile=\(shellQuote(knownHostsURL.path))"
+        ].joined(separator: " ")
+    }
+
+    private func run(executable: String, arguments: [String], currentDirectoryURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        logger.info("Running \(executable, privacy: .public) \(arguments.joined(separator: " "), privacy: .public)")
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+                ?? "unknown rsync error"
+            throw RsyncServiceError.commandFailed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    private func normalizeRelativePath(_ path: String) throws -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw RsyncServiceError.invalidDataPath(path)
+        }
+
+        let normalized = trimmed
+            .replacingOccurrences(of: "\\", with: "/")
+            .replacingOccurrences(of: #"^\./"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        if normalized.isEmpty {
+            return "data"
+        }
+        if normalized.hasPrefix("../") || normalized.contains("/../") || normalized == ".." {
+            throw RsyncServiceError.invalidDataPath(path)
+        }
+        return normalized
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/apps/DistributeMetal/Services/SSHService.swift
+++ b/apps/DistributeMetal/Services/SSHService.swift
@@ -1,0 +1,178 @@
+import Foundation
+import os.log
+
+enum SSHServiceError: LocalizedError {
+    case missingPublicKey(URL)
+    case rsyncUnavailable
+    case sshKeyscanFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPublicKey(let url):
+            return "Missing SSH public key at \(url.path)"
+        case .rsyncUnavailable:
+            return "The worker does not have rsync available for push sync."
+        case .sshKeyscanFailed(let message):
+            return "Failed to trust the worker SSH host key: \(message)"
+        }
+    }
+}
+
+/// Manages per-worker SSH identities for coordinator-driven push sync.
+///
+/// Each worker receives its own keypair and known-host entry so a compromised
+/// relationship can be rotated without affecting every other worker.
+final class SSHService {
+    static let shared = SSHService()
+
+    private let logger = Logger(subsystem: "one.measured.distribute-metal", category: "SSHService")
+    private let fileManager = FileManager.default
+
+    private init() {}
+
+    func configurePushAccess(for peer: Peer, client: AgentClient) async throws -> Peer {
+        let privateKeyURL = try ensureKeyPair(for: peer)
+        let publicKeyURL = privateKeyURL.appendingPathExtension("pub")
+        guard fileManager.fileExists(atPath: publicKeyURL.path) else {
+            throw SSHServiceError.missingPublicKey(publicKeyURL)
+        }
+
+        let publicKey = try String(contentsOf: publicKeyURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let keyName = "distribute-metal-\(sanitizedName(for: peer))"
+        let response = try await client.authorizeSSH(peer: peer, publicKey: publicKey, keyName: keyName)
+        guard response.rsyncAvailable else {
+            throw SSHServiceError.rsyncUnavailable
+        }
+
+        try trust(peer: peer, hostKeys: response.hostKeys)
+
+        var updated = peer
+        updated.sshUser = response.sshUser
+        updated.receiveRoot = response.receiveRoot
+        updated.sshConfigured = true
+        logger.info("Configured SSH push access for \(peer.name, privacy: .public)")
+        return updated
+    }
+
+    func privateKeyURL(for peer: Peer) throws -> URL {
+        try ensureKeyPair(for: peer)
+    }
+
+    func knownHostsURL() throws -> URL {
+        try ensureBaseDirectories()
+        let url = baseDirectory.appendingPathComponent("known_hosts")
+        if !fileManager.fileExists(atPath: url.path) {
+            fileManager.createFile(atPath: url.path, contents: nil)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        }
+        return url
+    }
+
+    private var baseDirectory: URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/distribute-metal/ssh", isDirectory: true)
+    }
+
+    private func ensureBaseDirectories() throws {
+        try fileManager.createDirectory(
+            at: baseDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+    }
+
+    private func ensureKeyPair(for peer: Peer) throws -> URL {
+        try ensureBaseDirectories()
+        let keyURL = baseDirectory.appendingPathComponent(sanitizedName(for: peer), isDirectory: false)
+        let publicKeyURL = keyURL.appendingPathExtension("pub")
+
+        if fileManager.fileExists(atPath: keyURL.path), fileManager.fileExists(atPath: publicKeyURL.path) {
+            return keyURL
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-keygen")
+        process.arguments = [
+            "-q",
+            "-t", "ed25519",
+            "-N", "",
+            "-C", "distribute-metal:\(peer.hostname)",
+            "-f", keyURL.path
+        ]
+        try run(process)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyURL.path)
+        try fileManager.setAttributes([.posixPermissions: 0o644], ofItemAtPath: publicKeyURL.path)
+        return keyURL
+    }
+
+    private func trust(peer: Peer, hostKeys: [String]) throws {
+        let knownHosts = try knownHostsURL()
+        var existing = ""
+        if fileManager.fileExists(atPath: knownHosts.path) {
+            existing = try String(contentsOf: knownHosts, encoding: .utf8)
+        }
+
+        let keysToWrite = hostKeys.isEmpty ? try scannedHostKeys(for: peer.ipAddress) : hostKeys
+        let hostAliases = Set([peer.ipAddress, peer.hostname]).filter { !$0.isEmpty }
+        let lines = hostAliases.flatMap { host in
+            keysToWrite.map { "\(host) \($0)" }
+        }
+
+        let missing = lines.filter { !existing.contains($0) }
+        guard !missing.isEmpty else { return }
+
+        let handle = try FileHandle(forWritingTo: knownHosts)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        for line in missing {
+            if !existing.isEmpty, !existing.hasSuffix("\n") {
+                try handle.write(contentsOf: Data("\n".utf8))
+                existing.append("\n")
+            }
+            try handle.write(contentsOf: Data("\(line)\n".utf8))
+            existing.append("\(line)\n")
+        }
+    }
+
+    private func scannedHostKeys(for host: String) throws -> [String] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-keyscan")
+        process.arguments = ["-T", "5", host]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try run(process)
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let lines = output
+            .split(separator: "\n")
+            .map(String.init)
+            .compactMap { line -> String? in
+                let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+                guard parts.count == 2 else { return nil }
+                return parts[1]
+            }
+        guard !lines.isEmpty else {
+            throw SSHServiceError.sshKeyscanFailed("No host keys returned for \(host)")
+        }
+        return lines
+    }
+
+    private func run(_ process: Process) throws {
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let message = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "unknown SSH error"
+            throw SSHServiceError.sshKeyscanFailed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    private func sanitizedName(for peer: Peer) -> String {
+        peer.hostname
+            .lowercased()
+            .replacingOccurrences(of: ".local", with: "")
+            .replacingOccurrences(of: "[^a-z0-9-]+", with: "-", options: .regularExpression)
+    }
+}

--- a/apps/DistributeMetal/Utilities/YAMLGenerator.swift
+++ b/apps/DistributeMetal/Utilities/YAMLGenerator.swift
@@ -22,7 +22,9 @@ enum YAMLGenerator {
             throw Error.noPyproject(root)
         }
 
-        let entrypoint = detectEntrypoint(in: projectURL) ?? "train.py"
+        let detectedEntrypoint = detectEntrypoint(in: projectURL) ?? "train.py"
+        let workingDir = workingDirectory(for: detectedEntrypoint)
+        let entrypoint = URL(fileURLWithPath: detectedEntrypoint).lastPathComponent
         let name = projectURL.lastPathComponent
             .replacingOccurrences(of: " ", with: "-")
             .lowercased()
@@ -35,6 +37,8 @@ enum YAMLGenerator {
 
         project:
           name: "\(name)"
+          root: "."
+          working_dir: "\(workingDir)"
           entrypoint: "\(entrypoint)"
           include:
             - "**/*.py"
@@ -83,7 +87,7 @@ enum YAMLGenerator {
 
 
         sync:
-          mode: "bulk"
+          mode: "rsync-push"
           parallel_connections: 8
           chunk_size_mb: 64
 
@@ -126,6 +130,11 @@ enum YAMLGenerator {
         }
 
         return nil
+    }
+
+    private static func workingDirectory(for entrypoint: String) -> String {
+        let directory = URL(fileURLWithPath: entrypoint).deletingLastPathComponent().path
+        return directory.isEmpty || directory == "/" ? "." : directory
     }
 
     private static func detectDataDirs(in url: URL) -> [String] {

--- a/apps/DistributeMetal/Views/MenuBarView.swift
+++ b/apps/DistributeMetal/Views/MenuBarView.swift
@@ -5,6 +5,7 @@ struct MenuBarView: View {
     @EnvironmentObject var orchestrator: JobOrchestrator
 
     @State private var showAddPeer = false
+    @State private var peerActionError: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -19,6 +20,14 @@ struct MenuBarView: View {
         .frame(width: 360)
         .sheet(isPresented: $showAddPeer) {
             AddPeerSheet(discovery: discovery)
+        }
+        .alert("Peer Action Failed", isPresented: Binding(
+            get: { peerActionError != nil },
+            set: { if !$0 { peerActionError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(peerActionError ?? "Unknown error")
         }
     }
 
@@ -95,7 +104,19 @@ struct MenuBarView: View {
                 .padding(.vertical, 8)
             } else {
                 ForEach(Array(discovery.discoveredPeers.values).sorted(by: { $0.name < $1.name }), id: \.id) { peer in
-                    PeerRow(peer: peer) {
+                    PeerRow(
+                        peer: peer,
+                        isBenchmarking: discovery.benchmarkingPeerIDs.contains(peer.id),
+                        onBenchmark: {
+                            Task {
+                                do {
+                                    try await discovery.benchmarkPeer(peer)
+                                } catch {
+                                    peerActionError = error.localizedDescription
+                                }
+                            }
+                        }
+                    ) {
                         discovery.removePeer(ip: peer.ipAddress)
                     }
                 }

--- a/apps/DistributeMetal/Views/PeerRow.swift
+++ b/apps/DistributeMetal/Views/PeerRow.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct PeerRow: View {
     let peer: Peer
+    var isBenchmarking = false
+    var onBenchmark: (() -> Void)?
     var onRemove: (() -> Void)?
 
     var body: some View {
@@ -28,11 +30,18 @@ struct PeerRow: View {
                 }
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+
+                if let detail = detailText {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                }
             }
 
             Spacer()
 
-            Text(peer.status.rawValue)
+            Text(peer.statusLabel)
                 .font(.caption2)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
@@ -42,19 +51,31 @@ struct PeerRow: View {
         }
         .padding(.vertical, 2)
         .contextMenu {
+            if let onBenchmark {
+                Button(isBenchmarking ? "Testing Link..." : "Test Link", action: onBenchmark)
+                    .disabled(isBenchmarking)
+            }
             if let onRemove {
                 Button("Remove", role: .destructive, action: onRemove)
             }
         }
     }
 
+    private var detailText: String? {
+        if let throughput = peer.lastBenchmarkMbps {
+            let latency = peer.lastBenchmarkLatencyMs.map { String(format: "%.1f ms", $0) } ?? "n/a"
+            return String(format: "%.0f Mbps • %@", throughput, latency)
+        }
+        return peer.statusDetail
+    }
+
     private var statusColor: Color {
         switch peer.status {
         case .discovered: return .yellow
-        case .paired, .ready: return .green
-        case .preflight: return .blue
+        case .unreachable: return .gray
+        case .agentFailed: return .red
+        case .ready: return .green
         case .busy: return .orange
-        case .offline: return .gray
         }
     }
 }

--- a/cursorinstructions.md
+++ b/cursorinstructions.md
@@ -1,0 +1,10 @@
+# DistributeMetal implementation notes
+
+- Treat Bonjour discovery and agent health as separate states. A peer can be visible on the LAN and still be unreachable or agent-failed.
+- Default sync mode is coordinator-driven `rsync` over SSH. Do not reintroduce peer-side pull as the primary path.
+- Workers must not receive credentials that allow direct read access back into the coordinator's live project directory.
+- SSH access is per-worker and push-only. Use restricted forced-command rsync on workers.
+- The worker job flow is `init -> rsync push -> prepare/provision -> launch`, not `prepare` first.
+- Launch must honor the job spec entrypoint, working directory, script args, and training environment.
+- MCP is optional. It remains useful for YAML generation and inspection, but sync and benchmarking must work without it.
+- Peer benchmark results should reflect the real worker-to-worker path, not only coordinator HTTP latency.

--- a/examples/mccl_ddp_train/distribute-metal.yaml
+++ b/examples/mccl_ddp_train/distribute-metal.yaml
@@ -37,7 +37,7 @@ training:
 data: []
 
 sync:
-  mode: bulk
+  mode: rsync-push
   parallel_connections: 4
   chunk_size_mb: 64
   preferred_interface: auto

--- a/schemas/distribute-metal.v1.yaml
+++ b/schemas/distribute-metal.v1.yaml
@@ -53,9 +53,9 @@ data: []
 
 # ── sync ─────────────────────────────────────────────────────────────────────
 sync:
-  mode: "bulk"                # bulk (parallel HTTP range fetch)
-  parallel_connections: 8     # concurrent download connections per worker
-  chunk_size_mb: 64           # per-range chunk size
+  mode: "rsync-push"          # rsync-push (coordinator-initiated SSH push)
+  parallel_connections: 8     # reserved for future multi-stream sync modes
+  chunk_size_mb: 64           # reserved for future chunked sync modes
   preferred_interface: "auto" # auto | thunderbolt | ethernet | wifi
 
 # ── cleanup ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- split peer discovery from agent reachability and add per-peer link diagnostics so Bonjour-visible workers are not collapsed into a generic offline state
- add coordinator-driven `rsync` over SSH into worker job workspaces with restricted authorization, saved job specs, and a sync-before-prepare lifecycle
- update worker launch to honor YAML `entrypoint`, `working_dir`, script args, and environment, while keeping MCP optional

## Why
- discovered peers could still show as a generic offline state even when the real failure was only agent reachability
- workers had no built-in secure source distribution path
- the live coordinator source directory must not be readable from peer machines
- operators need a real worker-to-worker link test before launching training

Closes #3

## Test plan
- [x] `swift build`
- [x] `python3 -m compileall agent/src/distribute_metal_agent`
- [x] `uv run --with pytest pytest tests/test_rsync_guard.py tests/test_runner_paths.py`
- [ ] Run a real two-Mac sync and launch flow with worker SSH bootstrap
- [ ] Run the peer link test from the menu bar UI on a live LAN